### PR TITLE
v1.1.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ minecraft_version=1.21.1
 loader_version=0.16.9
 
 # Mod Properties
-mod_version=1.6-fabric-1.0.0
+mod_version=1.6-fabric-1.1.0
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=friendsforever
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
@@ -33,26 +33,18 @@ object FriendsForeverMod : FabricMod<FriendsForeverConfig>(
 
     fun attemptFeed(pokemonEntity: PokemonEntity, stack: ItemStack, playerEntity: ServerPlayer) {
         val pokemon = pokemonEntity.pokemon
-        if (AFFECTION.getForPlayer(pokemon, playerEntity) >= config.maxPoints) {
-            playerEntity.sendSystemMessage(
-                Component.translatable(
-                    "friends_forever.feeding.full",
-                    pokemon.getDisplayName()
-                ),
-                true
-            )
-            return
-        }
+
         val matched = FeedInteractionRecipe.Manager.getStrongest(stack, pokemon) ?: return
         val added = matched.getEffectValue(pokemon)
         val effect = matched.getLikeBooster(pokemon)
+
         val preEvent = FeedEvent.Pre(stack, pokemon, playerEntity, matched, added)
         FriendsForeverEvents.FEED_PRE.postThen(
             preEvent,
             ifSucceeded = {
                 AFFECTION.updateForPlayer(
                     pokemon, playerEntity
-                ) { it + preEvent.added }
+                ) { min(it + preEvent.added, config.maxPoints) }
                 val effectivenessMessage = if (effect > 1) {
                     "friends_forever.feeding.liked"
                 } else if (effect < 1) {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
@@ -46,12 +46,13 @@ object FriendsForeverMod : FabricMod<FriendsForeverConfig>(
         val matched = FeedInteractionRecipe.Manager.getStrongest(stack, pokemon) ?: return
         val added = matched.getEffectValue(pokemon)
         val effect = matched.getLikeBooster(pokemon)
+        val preEvent = FeedEvent.Pre(stack, pokemon, playerEntity, matched, added)
         FriendsForeverEvents.FEED_PRE.postThen(
-            FeedEvent.Pre(stack, pokemon, playerEntity, matched),
+            preEvent,
             ifSucceeded = {
                 AFFECTION.updateForPlayer(
                     pokemon, playerEntity
-                ) { it + added }
+                ) { it + preEvent.added }
                 val effectivenessMessage = if (effect > 1) {
                     "friends_forever.feeding.liked"
                 } else if (effect < 1) {
@@ -84,7 +85,7 @@ object FriendsForeverMod : FabricMod<FriendsForeverConfig>(
                 stack.shrink(1)
                 if (pokemon.isReallyWild()) attemptJoinParty(pokemonEntity, playerEntity)
                 FriendsForeverEvents.FEED_POST.post(
-                    FeedEvent.Post(stack, pokemon, playerEntity, matched)
+                    FeedEvent.Post(stack, pokemon, playerEntity, matched, preEvent.added)
                 )
             }
         )

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
@@ -44,7 +44,6 @@ object FriendsForeverMod : FabricMod<FriendsForeverConfig>(
             FeedEvent.Pre(stack, pokemon, playerEntity, matched),
             ifSucceeded = {
                 matched.affectPokemon(pokemon, playerEntity)
-                stack.shrink(1)
                 val effect = matched.getLikeBooster(pokemon)
                 val effectivenessMessage = if (effect > 1) {
                     "friends_forever.feeding.liked"
@@ -60,6 +59,7 @@ object FriendsForeverMod : FabricMod<FriendsForeverConfig>(
                         stack.displayName
                     ), true
                 )
+                stack.shrink(1)
                 if (pokemon.isReallyWild()) attemptJoinParty(pokemonEntity, playerEntity)
                 FriendsForeverEvents.FEED_POST.post(
                     FeedEvent.Post(stack, pokemon, playerEntity, matched)

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/api/tim/cobblemon/PokemonExtensions.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/api/tim/cobblemon/PokemonExtensions.kt
@@ -1,5 +1,9 @@
 package us.timinc.mc.cobblemon.friendsforever.api.tim.cobblemon
 
+import com.cobblemon.mod.common.api.pokemon.PokemonProperties
 import com.cobblemon.mod.common.pokemon.Pokemon
 
 fun Pokemon.isReallyWild() = this.isWild() && this.originalTrainer === null
+
+fun Pokemon.matchesQuery(string: String) =
+    PokemonProperties.parse(string).matches(this) || this.form.labels.contains(string)

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/config/FriendsForeverConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/config/FriendsForeverConfig.kt
@@ -6,4 +6,5 @@ class FriendsForeverConfig {
     val maxPoints: Float = 255F
     val rate: Float = 5F
     val showAffectionOnFeed: Boolean = false
+    val showHeartsOnFeed: Boolean = false
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/config/FriendsForeverConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/config/FriendsForeverConfig.kt
@@ -5,4 +5,5 @@ class FriendsForeverConfig {
     val maxChance: Float = 1F
     val maxPoints: Float = 255F
     val rate: Float = 5F
+    val showAffectionOnFeed: Boolean = false
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/event/FeedEvent.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/event/FeedEvent.kt
@@ -11,12 +11,14 @@ interface FeedEvent {
     val pokemon: Pokemon
     val player: ServerPlayer
     val recipe: FeedInteractionRecipe
+    var added: Float
 
     class Pre(
         override val stack: ItemStack,
         override val pokemon: Pokemon,
         override val player: ServerPlayer,
         override val recipe: FeedInteractionRecipe,
+        override var added: Float,
     ) : FeedEvent, Cancelable()
 
     class Post(
@@ -24,5 +26,6 @@ interface FeedEvent {
         override val pokemon: Pokemon,
         override val player: ServerPlayer,
         override val recipe: FeedInteractionRecipe,
+        override var added: Float,
     ) : FeedEvent
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/recipe/FeedInteractionRecipe.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/recipe/FeedInteractionRecipe.kt
@@ -1,10 +1,12 @@
 package us.timinc.mc.cobblemon.friendsforever.recipe
 
+import com.cobblemon.mod.common.api.pokemon.PokemonProperties
 import com.cobblemon.mod.common.pokemon.Pokemon
 import com.google.gson.Gson
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import com.mojang.serialization.JsonOps
+import com.mojang.serialization.codecs.PrimitiveCodec
 import net.fabricmc.fabric.api.resource.IdentifiableResourceReloadListener
 import net.minecraft.resources.ResourceLocation
 import net.minecraft.server.level.ServerPlayer
@@ -16,6 +18,7 @@ import net.minecraft.world.item.crafting.Ingredient
 import us.timinc.mc.cobblemon.friendsforever.FriendsForeverMod.config
 import us.timinc.mc.cobblemon.friendsforever.FriendsForeverMod.modResource
 import us.timinc.mc.cobblemon.friendsforever.api.tim.cobblemon.food.FlavorStrength
+import us.timinc.mc.cobblemon.friendsforever.api.tim.cobblemon.matchesQuery
 import us.timinc.mc.cobblemon.friendsforever.api.tim.gson.getOrNull
 import us.timinc.mc.cobblemon.friendsforever.api.tim.minecraft.Conditions
 import us.timinc.mc.cobblemon.friendsforever.api.tim.minecraft.getOrNull
@@ -26,6 +29,8 @@ interface FeedInteractionRecipe {
     val food: Conditions.Ingredient
     val baseAffection: Int
     val flavors: List<FlavorStrength>
+    val blacklist: List<String>
+    val whitelist: List<String>
 
     fun affectPokemon(pokemon: Pokemon, feeder: ServerPlayer)
 
@@ -38,6 +43,8 @@ interface FeedInteractionRecipe {
         override val food: Conditions.Ingredient,
         override val baseAffection: Int,
         override val flavors: List<FlavorStrength>,
+        override val blacklist: List<String>,
+        override val whitelist: List<String>,
     ) : FeedInteractionRecipe {
         override fun affectPokemon(pokemon: Pokemon, feeder: ServerPlayer) {
             FriendsForeverPersistentProperties.AFFECTION.updateForPlayer(
@@ -77,18 +84,26 @@ interface FeedInteractionRecipe {
                 ?: throw Error("Invalid food for recipe $id.")
             val baseAffection =
                 data.getOrNull("baseAffection")?.asInt ?: throw Error("Invalid baseAffection for recipe $id.")
-            val flavors = data.getOrNull("flavors")?.asJsonArray ?: throw Error("Invalid flavors for recipe $id.")
+            val flavors = data.getOrNull("flavors")?.asJsonArray
+            val whitelist = data.getOrNull("whitelist")?.asJsonArray
+            val blacklist = data.getOrNull("blacklist")?.asJsonArray
 
             return Basic(
                 id,
                 Conditions.Ingredient(food),
                 baseAffection,
-                FlavorStrength.CODEC.listOf().parse(JsonOps.INSTANCE, flavors).orThrow
+                FlavorStrength.CODEC.listOf().orElse(emptyList()).parse(JsonOps.INSTANCE, flavors).orThrow,
+                PrimitiveCodec.STRING.listOf().orElse(emptyList()).parse(JsonOps.INSTANCE, blacklist).orThrow,
+                PrimitiveCodec.STRING.listOf().orElse(emptyList()).parse(JsonOps.INSTANCE, whitelist).orThrow,
             )
         }
 
-        fun getStrongest(stack: ItemStack, pokemon: Pokemon): FeedInteractionRecipe? =
-            recipes.filter { it.food.test(stack) }.maxByOrNull { it.getEffectValue(pokemon) }
+        fun getStrongest(stack: ItemStack, pokemon: Pokemon): FeedInteractionRecipe? = recipes.filter { recipe ->
+            val foodMatches = recipe.food.test(stack)
+            val whitelistMatches = recipe.whitelist.isEmpty() || recipe.whitelist.any(pokemon::matchesQuery)
+            val blacklistMatches = recipe.blacklist.none(pokemon::matchesQuery)
+            return@filter foodMatches && whitelistMatches && blacklistMatches
+        }.maxByOrNull { it.getEffectValue(pokemon) }
 
         override fun getFabricId(): ResourceLocation = modResource("feed_interaction")
     }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/recipe/FeedInteractionRecipe.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/recipe/FeedInteractionRecipe.kt
@@ -1,6 +1,5 @@
 package us.timinc.mc.cobblemon.friendsforever.recipe
 
-import com.cobblemon.mod.common.api.pokemon.PokemonProperties
 import com.cobblemon.mod.common.pokemon.Pokemon
 import com.google.gson.Gson
 import com.google.gson.JsonElement

--- a/src/main/resources/assets/friends_forever/lang/en_us.json
+++ b/src/main/resources/assets/friends_forever/lang/en_us.json
@@ -1,5 +1,4 @@
 {
-  "friends_forever.feeding.full": "%1$s is full of affection towards you!%3$s",
   "friends_forever.feeding.liked": "%1$s liked the %2$s you fed it.%3$s",
   "friends_forever.feeding.disliked": "%1$s disliked the %2$s you fed it.%3$s",
   "friends_forever.feeding.confirm": "%1$s thanks you for the %2$s.%3$s",

--- a/src/main/resources/assets/friends_forever/lang/en_us.json
+++ b/src/main/resources/assets/friends_forever/lang/en_us.json
@@ -1,6 +1,7 @@
 {
-  "friends_forever.feeding.full": "%1$s is full of affection towards you!",
-  "friends_forever.feeding.liked": "%1$s liked the %2$s you fed it.",
-  "friends_forever.feeding.disliked": "%1$s disliked the %2$s you fed it.",
-  "friends_forever.feeding.confirm": "%1$s thanks you for the %2$s."
+  "friends_forever.feeding.full": "%1$s is full of affection towards you!%3$s",
+  "friends_forever.feeding.liked": "%1$s liked the %2$s you fed it.%3$s",
+  "friends_forever.feeding.disliked": "%1$s disliked the %2$s you fed it.%3$s",
+  "friends_forever.feeding.confirm": "%1$s thanks you for the %2$s.%3$s",
+  "friends_forever.parts.current_affection": " (%1$s)"
 }

--- a/src/main/resources/data/friends_forever/feed_interaction/cobblemon/berry_sweet.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/cobblemon/berry_sweet.json
@@ -1,0 +1,17 @@
+{
+  "food": {
+    "item": "cobblemon:berry_sweet"
+  },
+  "baseAffection": 15,
+  "flavors": [
+    {
+      "flavor": "BITTER"
+    },
+    {
+      "flavor": "SOUR"
+    }
+  ],
+  "blacklist": [
+    "alcremie"
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/cobblemon/clover_sweet.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/cobblemon/clover_sweet.json
@@ -1,0 +1,17 @@
+{
+  "food": {
+    "item": "cobblemon:clover_sweet"
+  },
+  "baseAffection": 15,
+  "flavors": [
+    {
+      "flavor": "BITTER"
+    },
+    {
+      "flavor": "DRY"
+    }
+  ],
+  "blacklist": [
+    "alcremie"
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/cobblemon/flower_sweet.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/cobblemon/flower_sweet.json
@@ -1,0 +1,17 @@
+{
+  "food": {
+    "item": "cobblemon:flower_sweet"
+  },
+  "baseAffection": 15,
+  "flavors": [
+    {
+      "flavor": "SPICY"
+    },
+    {
+      "flavor": "DRY"
+    }
+  ],
+  "blacklist": [
+    "alcremie"
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/cobblemon/star_sweet.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/cobblemon/star_sweet.json
@@ -1,0 +1,17 @@
+{
+  "food": {
+    "item": "cobblemon:star_sweet"
+  },
+  "baseAffection": 15,
+  "flavors": [
+    {
+      "flavor": "SPICY"
+    },
+    {
+      "flavor": "SWEET"
+    }
+  ],
+  "blacklist": [
+    "alcremie"
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/cobblemon/strawberry_sweet.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/cobblemon/strawberry_sweet.json
@@ -1,0 +1,17 @@
+{
+  "food": {
+    "item": "cobblemon:strawberry_sweet"
+  },
+  "baseAffection": 15,
+  "flavors": [
+    {
+      "flavor": "SWEET"
+    },
+    {
+      "flavor": "SOUR"
+    }
+  ],
+  "blacklist": [
+    "alcremie"
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/apple.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/apple.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:apple"
+  },
+  "baseAffection": 5,
+  "flavors": [
+    {
+      "flavor": "SWEET"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/beef.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/beef.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:beef"
+  },
+  "baseAffection": 8,
+  "flavors": [
+    {
+      "flavor": "BITTER"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/beetroot.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/beetroot.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:beetroot"
+  },
+  "baseAffection": 5,
+  "flavors": [
+    {
+      "flavor": "BITTER"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/carrot.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/carrot.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:carrot"
+  },
+  "baseAffection": 5,
+  "flavors": [
+    {
+      "flavor": "SOUR"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/chicken.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/chicken.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:chicken"
+  },
+  "baseAffection": 8,
+  "flavors": [
+    {
+      "flavor": "SOUR"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/chorus_fruit.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/chorus_fruit.json
@@ -1,0 +1,6 @@
+{
+  "food": {
+    "item": "minecraft:chorus_fruit"
+  },
+  "baseAffection": 2
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/cooked_chicken.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/cooked_chicken.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:cooked_chicken"
+  },
+  "baseAffection": 16,
+  "flavors": [
+    {
+      "flavor": "SOUR"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/cooked_mutton.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/cooked_mutton.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:cooked_mutton"
+  },
+  "baseAffection": 16,
+  "flavors": [
+    {
+      "flavor": "SPICY"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/cooked_porkchop.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/cooked_porkchop.json
@@ -1,8 +1,8 @@
 {
   "food": {
-    "item": "minecraft:bread"
+    "item": "minecraft:cooked_porkchop"
   },
-  "baseAffection": 10,
+  "baseAffection": 16,
   "flavors": [
     {
       "flavor": "DRY"

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/cooked_rabbit.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/cooked_rabbit.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:cooked_rabbit"
+  },
+  "baseAffection": 16,
+  "flavors": [
+    {
+      "flavor": "SWEET"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/enchanted_golden_apple.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/enchanted_golden_apple.json
@@ -1,0 +1,6 @@
+{
+  "food": {
+    "item": "minecraft:enchanted_golden_apple"
+  },
+  "baseAffection": 100
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/glow_berries.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/glow_berries.json
@@ -1,0 +1,6 @@
+{
+  "food": {
+    "item": "minecraft:glow_berries"
+  },
+  "baseAffection": 2
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/golden_apple.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/golden_apple.json
@@ -1,0 +1,6 @@
+{
+  "food": {
+    "item": "minecraft:golden_apple"
+  },
+  "baseAffection": 50
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/golden_carrot.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/golden_carrot.json
@@ -1,0 +1,6 @@
+{
+  "food": {
+    "item": "minecraft:golden_carrot"
+  },
+  "baseAffection": 35
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/honey_bottle.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/honey_bottle.json
@@ -1,0 +1,6 @@
+{
+  "food": {
+    "item": "minecraft:honey_bottle"
+  },
+  "baseAffection": 5
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/melon_slice.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/melon_slice.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:melon_slice"
+  },
+  "baseAffection": 5,
+  "flavors": [
+    {
+      "flavor": "SPICY"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/mutton.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/mutton.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:mutton"
+  },
+  "baseAffection": 8,
+  "flavors": [
+    {
+      "flavor": "SPICY"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/porkchop.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/porkchop.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:porkchop"
+  },
+  "baseAffection": 8,
+  "flavors": [
+    {
+      "flavor": "DRY"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/potato.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/potato.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:potato"
+  },
+  "baseAffection": 5,
+  "flavors": [
+    {
+      "flavor": "DRY"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/rabbit.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/rabbit.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:rabbit"
+  },
+  "baseAffection": 8,
+  "flavors": [
+    {
+      "flavor": "SWEET"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/steak.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/steak.json
@@ -1,0 +1,11 @@
+{
+  "food": {
+    "item": "minecraft:cooked_beef"
+  },
+  "baseAffection": 16,
+  "flavors": [
+    {
+      "flavor": "BITTER"
+    }
+  ]
+}

--- a/src/main/resources/data/friends_forever/feed_interaction/minecraft/sweet_berries.json
+++ b/src/main/resources/data/friends_forever/feed_interaction/minecraft/sweet_berries.json
@@ -1,0 +1,6 @@
+{
+  "food": {
+    "item": "minecraft:sweet_berries"
+  },
+  "baseAffection": 2
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "friends_forever",
-  "version": "1.6-fabric-1.0.0",
+  "version": "1.6-fabric-1.1.0",
   "name": "Friends Forever",
   "description": "Feed Pokemon to grow their affection and make them join your team in Cobblemon!",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
   "id": "friends_forever",
   "version": "1.6-fabric-1.0.0",
   "name": "Friends Forever",
-  "description": "An alternative to catching Pokemon in Cobblemon; just feed them until they like you!",
+  "description": "Feed Pokemon to grow their affection and make them join your team in Cobblemon!",
   "authors": [
     "timinc aka Timothy Metcalfe"
   ],


### PR DESCRIPTION
* Added several Minecraft items as foods. Tried to keep it kinda flat in terms of what was added, so that there was a variant for each flavor in a given category.
* Added the Alcremie sweets from Cobblemon as foods. Each one has a combination of two flavors with a balanced strength between the two.
* Added whitelist and blacklist to recipes, so you can navigate those items having specific uses for certain Pokémon, or just go ham and make, say, custom labels such that only some types of Pokémon can eat some types of foods.
* Feeding now optionally gives current affection level back in feedback.
* Added optional hearts particles on feed.
* The FeedEvent now has access to the amount of affection added. Pre can modify it.
* Pokémon will no longer be full and unable to try and love you enough to join your team.
* Pokémon will no longer thank you for the air you gave them.