### PR TITLE
v1.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ minecraft_version=1.21.1
 loader_version=0.16.9
 
 # Mod Properties
-mod_version=1.6-fabric-1.1.0
+mod_version=1.6-fabric-1.1.1
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=friendsforever
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ minecraft_version=1.21.1
 loader_version=0.16.9
 
 # Mod Properties
-mod_version=1.6-fabric-1.0.0
+mod_version=1.6-fabric-1.1.0
 maven_group=us.timinc.mc.cobblemon
 archives_base_name=friendsforever
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
@@ -100,8 +100,13 @@ object FriendsForeverMod : FabricMod<FriendsForeverConfig>(
                     1.0
                 )
             }
+            playerEntity.sendSystemMessage(
+                Component.translatable(
+                    "friends_forever.feeding.joined",
+                    pokemonEntity.pokemon.getDisplayName()
+                ), true
+            )
             pokemonEntity.discard()
-            playerEntity.sendSystemMessage(Component.literal("The Pokemon has joined your party!"), true)
         }
     }
 

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
@@ -33,26 +33,18 @@ object FriendsForeverMod : FabricMod<FriendsForeverConfig>(
 
     fun attemptFeed(pokemonEntity: PokemonEntity, stack: ItemStack, playerEntity: ServerPlayer) {
         val pokemon = pokemonEntity.pokemon
-        if (AFFECTION.getForPlayer(pokemon, playerEntity) >= config.maxPoints) {
-            playerEntity.sendSystemMessage(
-                Component.translatable(
-                    "friends_forever.feeding.full",
-                    pokemon.getDisplayName()
-                ),
-                true
-            )
-            return
-        }
+
         val matched = FeedInteractionRecipe.Manager.getStrongest(stack, pokemon) ?: return
         val added = matched.getEffectValue(pokemon)
         val effect = matched.getLikeBooster(pokemon)
+
         val preEvent = FeedEvent.Pre(stack, pokemon, playerEntity, matched, added)
         FriendsForeverEvents.FEED_PRE.postThen(
             preEvent,
             ifSucceeded = {
                 AFFECTION.updateForPlayer(
                     pokemon, playerEntity
-                ) { it + preEvent.added }
+                ) { min(it + preEvent.added, config.maxPoints) }
                 val effectivenessMessage = if (effect > 1) {
                     "friends_forever.feeding.liked"
                 } else if (effect < 1) {

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
@@ -91,6 +91,7 @@ object FriendsForeverMod : FabricMod<FriendsForeverConfig>(
         val roll = nextFloat()
         if (roll <= joinChance) {
             Cobblemon.storage.getParty(playerEntity).add(pokemonEntity.pokemon)
+            pokemonEntity.discard()
             playerEntity.sendSystemMessage(Component.literal("The Pokemon has joined your party!"), true)
         }
     }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/FriendsForeverMod.kt
@@ -91,6 +91,15 @@ object FriendsForeverMod : FabricMod<FriendsForeverConfig>(
         val roll = nextFloat()
         if (roll <= joinChance) {
             Cobblemon.storage.getParty(playerEntity).add(pokemonEntity.pokemon)
+            if (config.showPoofOnJoin) {
+                pokemonEntity.level().sendParticlesServer(
+                    ParticleTypes.POOF,
+                    pokemonEntity.position(),
+                    8,
+                    Vec3.ZERO,
+                    1.0
+                )
+            }
             pokemonEntity.discard()
             playerEntity.sendSystemMessage(Component.literal("The Pokemon has joined your party!"), true)
         }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/config/FriendsForeverConfig.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/config/FriendsForeverConfig.kt
@@ -7,4 +7,5 @@ class FriendsForeverConfig {
     val rate: Float = 5F
     val showAffectionOnFeed: Boolean = false
     val showHeartsOnFeed: Boolean = false
+    val showPoofOnJoin: Boolean = true
 }

--- a/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/recipe/FeedInteractionRecipe.kt
+++ b/src/main/kotlin/us/timinc/mc/cobblemon/friendsforever/recipe/FeedInteractionRecipe.kt
@@ -1,6 +1,5 @@
 package us.timinc.mc.cobblemon.friendsforever.recipe
 
-import com.cobblemon.mod.common.api.pokemon.PokemonProperties
 import com.cobblemon.mod.common.pokemon.Pokemon
 import com.google.gson.Gson
 import com.google.gson.JsonElement

--- a/src/main/resources/assets/friends_forever/lang/en_us.json
+++ b/src/main/resources/assets/friends_forever/lang/en_us.json
@@ -1,5 +1,4 @@
 {
-  "friends_forever.feeding.full": "%1$s is full of affection towards you!%3$s",
   "friends_forever.feeding.liked": "%1$s liked the %2$s you fed it.%3$s",
   "friends_forever.feeding.disliked": "%1$s disliked the %2$s you fed it.%3$s",
   "friends_forever.feeding.confirm": "%1$s thanks you for the %2$s.%3$s",

--- a/src/main/resources/assets/friends_forever/lang/en_us.json
+++ b/src/main/resources/assets/friends_forever/lang/en_us.json
@@ -2,5 +2,6 @@
   "friends_forever.feeding.liked": "%1$s liked the %2$s you fed it.%3$s",
   "friends_forever.feeding.disliked": "%1$s disliked the %2$s you fed it.%3$s",
   "friends_forever.feeding.confirm": "%1$s thanks you for the %2$s.%3$s",
-  "friends_forever.parts.current_affection": " (%1$s)"
+  "friends_forever.parts.current_affection": " (%1$s)",
+  "friends_forever.feeding.joined": "%1$s has joined your party!"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "friends_forever",
-  "version": "1.6-fabric-1.0.0",
+  "version": "1.6-fabric-1.1.0",
   "name": "Friends Forever",
   "description": "Feed Pokemon to grow their affection and make them join your team in Cobblemon!",
   "authors": [

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "friends_forever",
-  "version": "1.6-fabric-1.1.0",
+  "version": "1.6-fabric-1.1.1",
   "name": "Friends Forever",
   "description": "Feed Pokemon to grow their affection and make them join your team in Cobblemon!",
   "authors": [


### PR DESCRIPTION
* Discard the entity on join. Solves Pokémon joining your team via the PC but still being in the world.
* Added optional poof particles on join.
* Migrated join message to translatable.